### PR TITLE
PD Command line options

### DIFF
--- a/lib/puredata/pd.rb
+++ b/lib/puredata/pd.rb
@@ -31,7 +31,7 @@ class PureData
 
   def fork_pd(opt={})
     path = opt[:pd_app_path] || @@pd_app_path
-    pd_params = opt[:pd_params]
+    pd_params = opt[:pd_params] || [] 
     if path.nil? or not File.executable?(path)
       raise "option :pd_app_path (Pd-extended executable) must be specified."
     end


### PR DESCRIPTION
Hi, I've added the ability to add to the PD command line options via Pd.start.

I found that on linux that PD found my subpatch file just fine but on windows under cygwin I needed to add the path parameter explicitly.  I also found -verbose -stderr helpful.

Since it's just another key in the hash it doesn't break the API.
