### PR TITLE
Making it possible to install via a gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in puredata.gemspec
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,1 @@
+require "bundler/gem_tasks"

--- a/lib/puredata/version.rb
+++ b/lib/puredata/version.rb
@@ -1,0 +1,3 @@
+module Puredata
+  VERSION = "0.1.0"
+end

--- a/puredata.gemspec
+++ b/puredata.gemspec
@@ -1,0 +1,21 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'puredata/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = "puredata"
+  spec.version       = Puredata::VERSION
+  spec.authors       = ["CHIKANAGA Tomoyuki"]
+  spec.email         = ["nagachika00@gmail.com"]
+
+  spec.summary       = "Ruby library to manipulate PureData (Pd-extended) via socket."
+  spec.description   = "Ruby library to manipulate PureData (Pd-extended) via socket."
+  spec.homepage      = "https://github.com/nagachika/ruby-puredata"
+
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "rake", "~> 10.0"
+end


### PR DESCRIPTION
I really enjoy playing ruby-puredata, but taking into account the load path is sometimes a pain :astonished:

I have made it possible to use this library as a gem so that you can use it anywhere without considering the load path.

It would be pleasant if ruby-puredata is available via RubyGems as well.
